### PR TITLE
Add EICAR verification to ClamAV workflow

### DIFF
--- a/.github/workflows/clam-av.yml
+++ b/.github/workflows/clam-av.yml
@@ -41,6 +41,15 @@ jobs:
           ls -lh /var/lib/clamav
 
       # Scan extracted bundle so counts reflect actual files
+      - name: Verify ClamAV detects EICAR signature
+        run: |
+          set -e
+          printf 'X5O!P%%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > eicar.com
+          clamscan eicar.com | tee eicar.log
+          grep -q 'eicar.com: Eicar-Test-Signature FOUND' eicar.log
+          grep -q 'Infected files: 1' eicar.log
+          rm -f eicar.com eicar.log
+
       - name: Extract bundle and scan
         run: |
           set -e

--- a/.github/workflows/clam-av.yml
+++ b/.github/workflows/clam-av.yml
@@ -43,9 +43,15 @@ jobs:
       # Scan extracted bundle so counts reflect actual files
       - name: Verify ClamAV detects EICAR signature
         run: |
-          set -e
+          set -euo pipefail
           printf 'X5O!P%%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > eicar.com
-          clamscan eicar.com | tee eicar.log
+          status=0
+          clamscan eicar.com > eicar.log || status=$?
+          cat eicar.log
+          if [ "$status" -ne 1 ]; then
+            echo "ClamAV failed to report the EICAR signature" >&2
+            exit 1
+          fi
           grep -q 'eicar.com: Eicar-Test-Signature FOUND' eicar.log
           grep -q 'Infected files: 1' eicar.log
           rm -f eicar.com eicar.log


### PR DESCRIPTION
## Summary
- ensure the ClamAV workflow verifies that the engine detects the EICAR signature before scanning build artifacts

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68fe8f9c73ec83248fa2edfc357c185c