### PR TITLE
Deterministic Defender EICAR verification + forensics hooks

### DIFF
--- a/.github/workflows/windows-defender-scan.yml
+++ b/.github/workflows/windows-defender-scan.yml
@@ -85,6 +85,14 @@ jobs:
           cmd /c type scan\eicar.txt >NUL
           Start-Sleep -Seconds 3  # give logs a moment
 
+      - name: On-demand scan EICAR file
+        shell: pwsh
+        run: |
+          $scan = (Resolve-Path 'scan').Path
+          $target = Join-Path $scan 'eicar.txt'
+          & "$env:MPCMDRUN" -Scan -ScanType 3 -File $target
+          Start-Sleep -Seconds 3  # allow detection telemetry to flush
+
       # assert detection, but do NOT fail here; report via step output
       - name: Collect detections and set outputs
         id: detect


### PR DESCRIPTION
This PR builds on #1 and prepares a deterministic Windows Defender EICAR verification flow, with optional support bundle collection.

**Why**
- Make EICAR verification deterministic even when RTP is disabled/passive by invoking an explicit on-demand scan of the EICAR file (MpCmdRun -Scan -ScanType 3 -File <file>).
- Improve observability by uploading defender-detections.json always, and MpSupportFiles.cab when verification fails.

**Notes**
- Branch created from `devops/3415-windows-virus-false-positive` (commit 903121b).
- This PR is scaffolded and ready for the diff from the review I proposed; happy to push those changes next, or we can land them here.

---
Checklist
- [ ] Pin runner to `windows-2025` if you want image stability.
- [ ] Keep directory scan step for bundle after the EICAR verification gate.
- [ ] Consider job timeout + concurrency settings (added in patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adopted Bun 1.3.0 for builds and streamlined version resolution.
  * Added a unified build-and-package step producing a single distributable archive.
  * Restored automated code formatting as a CI pre-format step.

* **Security**
  * Added automated ClamAV and Windows Defender scanning of build artifacts.
  * Added OWASP dependency vulnerability scanning with report upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->