### PR TITLE
Increase Defender telemetry wait before polling

### DIFF
--- a/.github/workflows/windows-defender-scan.yml
+++ b/.github/workflows/windows-defender-scan.yml
@@ -131,6 +131,9 @@ jobs:
             return [pscustomobject]@{ Eicar = $eicarHits; Real = $realHits }
           }
 
+          # wait a bit before polling so telemetry has time to arrive on slow runners
+          Start-Sleep -Seconds 20
+
           # poll (up to 120s) because Defender threat history entries can be delayed
           $deadline = (Get-Date).AddSeconds(120)
           $interval = 5


### PR DESCRIPTION
## Summary
- add a 20-second delay before polling for Defender detections to reduce flakiness on slower runners

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_6902c18232188324abc09447279f8e68