### PR TITLE
Restore session deletion behavior

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -447,6 +447,8 @@ export namespace Server {
           }),
         ),
         async (c) => {
+          const sessionID = c.req.valid("param").id
+          await Session.remove(sessionID)
           await Bus.publish(TuiEvent.CommandExecute, {
             command: "session.list",
           })


### PR DESCRIPTION
## Summary
- restore the DELETE /session/:id handler to remove session data before notifying the TUI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69037c12b02c83248539b81825a4d4bb