### PR TITLE
fix: resolve bash tool path validation relative to cwd

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -69,6 +69,7 @@ export const BashTool = Tool.define("bash", {
     let workingDirectory = Instance.directory
     if (params.cwd) {
       const resolvedCwd = await $`realpath ${params.cwd}`
+        .cwd(Instance.directory)
         .quiet()
         .nothrow()
         .text()
@@ -113,6 +114,7 @@ export const BashTool = Tool.define("bash", {
         for (const arg of command.slice(1)) {
           if (arg.startsWith("-") || (command[0] === "chmod" && arg.startsWith("+"))) continue
           const resolved = await $`realpath ${arg}`
+            .cwd(workingDirectory)
             .quiet()
             .nothrow()
             .text()


### PR DESCRIPTION
## Summary
- resolve the requested working directory relative to the project root when using `realpath`
- validate destructive command arguments using the effective working directory so relative parent paths inside the project are accepted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903d154f9888324bfbfd8b138b07833