### PR TITLE
fix(snapshot): serialize snapshot git ops under contention

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -13,6 +13,59 @@ export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
   const hour = 60 * 60 * 1000
   const prune = "7.days"
+  type Gate = {
+    held: boolean
+    wait: (() => void)[]
+  }
+  const gate = new Map<string, Gate>()
+
+  function item(git: string) {
+    const existing = gate.get(git)
+    if (existing) return existing
+    const fresh: Gate = {
+      held: false,
+      wait: [],
+    }
+    gate.set(git, fresh)
+    return fresh
+  }
+
+  function unlock(git: string, lock: Gate) {
+    const next = lock.wait.shift()
+    if (next) {
+      next()
+      return
+    }
+    lock.held = false
+    if (!lock.held && lock.wait.length === 0) gate.delete(git)
+  }
+
+  function token(git: string, lock: Gate): Disposable {
+    return {
+      [Symbol.dispose]: () => unlock(git, lock),
+    }
+  }
+
+  function tryLock(git: string) {
+    const lock = item(git)
+    if (lock.held) return
+    lock.held = true
+    return token(git, lock)
+  }
+
+  async function lock(git: string): Promise<Disposable> {
+    const entry = item(git)
+    if (!entry.held) {
+      entry.held = true
+      return token(git, entry)
+    }
+    return new Promise((resolve) => {
+      entry.wait.push(() => {
+        entry.held = true
+        resolve(token(git, entry))
+      })
+    })
+  }
 
   export function init() {
     Scheduler.register({
@@ -28,6 +81,12 @@ export namespace Snapshot {
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()
+    const permit = tryLock(git)
+    if (!permit) {
+      log.info("cleanup skipped", { git, reason: "busy" })
+      return
+    }
+    using _ = permit
     const exists = await fs
       .stat(git)
       .then(() => true)
@@ -53,6 +112,7 @@ export namespace Snapshot {
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()
+    using _ = await lock(git)
     if (await fs.mkdir(git, { recursive: true })) {
       await $`git init`
         .env({
@@ -87,6 +147,7 @@ export namespace Snapshot {
 
   export async function patch(hash: string): Promise<Patch> {
     const git = gitdir()
+    using _ = await lock(git)
     await add(git)
     const result =
       await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-only ${hash} -- .`
@@ -115,6 +176,7 @@ export namespace Snapshot {
   export async function restore(snapshot: string) {
     log.info("restore", { commit: snapshot })
     const git = gitdir()
+    using _ = await lock(git)
     const result =
       await $`git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} read-tree ${snapshot} && git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} checkout-index -a -f`
         .quiet()
@@ -134,6 +196,7 @@ export namespace Snapshot {
   export async function revert(patches: Patch[]) {
     const files = new Set<string>()
     const git = gitdir()
+    using _ = await lock(git)
     for (const item of patches) {
       for (const file of item.files) {
         if (files.has(file)) continue
@@ -166,6 +229,7 @@ export namespace Snapshot {
 
   export async function diff(hash: string) {
     const git = gitdir()
+    using _ = await lock(git)
     await add(git)
     const result =
       await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff ${hash} -- .`
@@ -201,6 +265,7 @@ export namespace Snapshot {
   export type FileDiff = z.infer<typeof FileDiff>
   export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
     const git = gitdir()
+    using _ = await lock(git)
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
 

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1,10 +1,26 @@
-import { test, expect } from "bun:test"
+import { test, expect, mock } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
+
+mock.module("drizzle-orm/bun-sqlite/migrator", () => ({
+  migrate: (db: any, entries: any) => {
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        const statements = entry.sql.split("--> statement-breakpoint")
+        for (const stmt of statements) {
+          if (stmt.trim()) db.run(stmt)
+        }
+      }
+    }
+  },
+  readMigrationFiles: () => [],
+}))
+
 import { Snapshot } from "../../src/snapshot"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
+import { Global } from "../../src/global"
 import { tmpdir } from "../fixture/fixture"
 
 // Git always outputs /-separated paths internally. Snapshot.patch() joins them
@@ -601,6 +617,66 @@ test("concurrent file operations during patch", async () => {
 
       // Should capture some or all of the concurrent files
       expect(patch.files.length).toBeGreaterThanOrEqual(0)
+    },
+  })
+})
+
+test("concurrent snapshot operations do not leave git index lock", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      await Promise.all(
+        Array.from({ length: 24 }, (_, i) => Filesystem.write(`${tmp.path}/parallel-${i}.txt`, `parallel-${i}`)),
+      )
+
+      await Promise.all([
+        ...Array.from({ length: 8 }, () => Snapshot.track()),
+        ...Array.from({ length: 8 }, () => Snapshot.patch(before!)),
+        ...Array.from({ length: 8 }, () => Snapshot.diff(before!)),
+      ])
+
+      const lock = await fs
+        .access(path.join(Global.Path.data, "snapshot", Instance.project.id, "index.lock"))
+        .then(() => true)
+        .catch(() => false)
+      expect(lock).toBe(false)
+    },
+  })
+})
+
+test("cleanup returns immediately when snapshot repo is busy", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const busyFiles = Array.from({ length: 160 }, (_, i) => `${tmp.path}/busy-${i}.txt`)
+      const revertPromise = Snapshot.revert([
+        {
+          hash: before!,
+          files: busyFiles,
+        },
+      ])
+
+      const cleanupResult = await Promise.race([
+        Snapshot.cleanup().then(() => "cleanup" as const),
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 1000)),
+      ])
+      expect(cleanupResult).toBe("cleanup")
+
+      const stillRunning = await Promise.race([
+        revertPromise.then(() => false),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 30)),
+      ])
+      expect(stillRunning).toBe(true)
+
+      await revertPromise
     },
   })
 })


### PR DESCRIPTION
## Summary
This PR introduces a per-repo snapshot lock to serialize git operations (`track`, `patch`, `diff`, `cleanup`) and prevents `git gc` from running when the snapshot repo is busy. This addresses disk growth and lock contention issues observed in long-running sessions.

## Test Plan
- **Automated:** Added new tests in `packages/opencode/test/snapshot/snapshot.test.ts` covering concurrent snapshot operations and cleanup behavior under contention.
  - Run with: `bun test test/snapshot/snapshot.test.ts`
- **Manual:** Verified in a local environment with `fork_tales` vault that `index.lock` contention is reduced.

## Related Issues
Fixes #74