### PR TITLE
fix(snapshot): add phase5 runtime verification and loose-object compaction

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/snapshot.ts
+++ b/packages/opencode/src/cli/cmd/debug/snapshot.ts
@@ -1,11 +1,21 @@
+import { $ } from "bun"
+import fs from "fs/promises"
+import { EOL } from "os"
+import path from "path"
+import { Config } from "../../../config/config"
+import { Global } from "../../../global"
+import { Instance } from "../../../project/instance"
 import { Snapshot } from "../../../snapshot"
 import { bootstrap } from "../../bootstrap"
 import { cmd } from "../cmd"
 
+const hour = 60 * 60 * 1000
+
 export const SnapshotCommand = cmd({
   command: "snapshot",
   describe: "snapshot debugging utilities",
-  builder: (yargs) => yargs.command(TrackCommand).command(PatchCommand).command(DiffCommand).demandCommand(),
+  builder: (yargs) =>
+    yargs.command(TrackCommand).command(PatchCommand).command(DiffCommand).command(VerifyCommand).demandCommand(),
   async handler() {},
 })
 
@@ -50,3 +60,164 @@ const DiffCommand = cmd({
     })
   },
 })
+
+const VerifyCommand = cmd({
+  command: "verify",
+  describe: "run contention-heavy snapshot verification and report health",
+  builder: (yargs) =>
+    yargs
+      .option("iterations", {
+        type: "number",
+        default: 120,
+        description: "Number of churn iterations",
+      })
+      .option("concurrency", {
+        type: "number",
+        default: 8,
+        description: "Parallel operations per iteration",
+      })
+      .option("cleanup-every", {
+        type: "number",
+        default: 6,
+        description: "Run cleanup every N iterations",
+      }),
+  async handler(args) {
+    await bootstrap(process.cwd(), async () => {
+      const cfg = await Config.get()
+      if (cfg.snapshot === false) {
+        throw new Error("snapshot verification requires snapshot=true")
+      }
+      const iterations = Math.max(1, Math.floor(args.iterations ?? 120))
+      const concurrency = Math.max(1, Math.floor(args.concurrency ?? 8))
+      const cleanupEvery = Math.max(1, Math.floor(args["cleanup-every"] ?? 6))
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      const probe = path.join(Instance.worktree, ".opencode-snapshot-verify.tmp")
+      const existed = await fs
+        .stat(probe)
+        .then(() => true)
+        .catch(() => false)
+      const prior = existed ? await Bun.file(probe).text().catch(() => "") : ""
+
+      const started = Date.now()
+      const before = await health(git)
+
+      let hash = (await Snapshot.track()) ?? ""
+      if (!hash) {
+        const seed = await Promise.all(Array.from({ length: 4 }, () => Snapshot.track()))
+        const next = seed.find((item) => item)
+        hash = next ?? ""
+      }
+      if (!hash) throw new Error("failed to acquire initial snapshot hash")
+
+      try {
+        for (const i of Array.from({ length: iterations }, (_, i) => i)) {
+          await Bun.write(probe, `verify:${i}:${Date.now()}`)
+          const base = hash
+          const tasks = Array.from({ length: concurrency }, (_, j) => {
+            if (j % 3 === 0) return Snapshot.track().then((next) => next ?? "")
+            if (j % 3 === 1) return Snapshot.patch(base).then(() => "")
+            return Snapshot.diff(base).then(() => "")
+          })
+          if (i % cleanupEvery === 0) tasks.push(Snapshot.cleanup().then(() => ""))
+          for (const next of await Promise.all(tasks)) {
+            if (next) hash = next
+          }
+        }
+      } finally {
+        if (existed) await Bun.write(probe, prior)
+        else await fs.unlink(probe).catch(() => {})
+      }
+
+      await Snapshot.cleanup()
+      const after = await health(git)
+      const result = {
+        project: Instance.project.id,
+        git,
+        options: {
+          iterations,
+          concurrency,
+          cleanupEvery,
+        },
+        duration_ms: Date.now() - started,
+        before,
+        after,
+        delta: {
+          loose: after.count.loose - before.count.loose,
+          packs: after.count.packs - before.count.packs,
+          size_kib: after.count.size_kib - before.count.size_kib,
+          size_pack_kib: after.count.size_pack_kib - before.count.size_pack_kib,
+        },
+        ok: !after.index_lock && after.tmp_pack.stale === 0,
+      }
+
+      process.stdout.write(JSON.stringify(result, null, 2) + EOL)
+      if (!result.ok) process.exitCode = 1
+    })
+  },
+})
+
+async function health(git: string) {
+  const count = await countObjects(git)
+  const tmp = await tmpPacks(git)
+  const indexLock = await fs
+    .access(path.join(git, "index.lock"))
+    .then(() => true)
+    .catch(() => false)
+  return {
+    count,
+    index_lock: indexLock,
+    tmp_pack: {
+      total: tmp.length,
+      stale: tmp.filter((item) => item.age_ms > hour).length,
+      files: tmp,
+    },
+  }
+}
+
+async function countObjects(git: string) {
+  const text = await $`git --git-dir ${git} count-objects -v`.quiet().nothrow().text()
+  const entries = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const i = line.indexOf(":")
+      if (i < 0) return []
+      return [[line.slice(0, i).trim(), line.slice(i + 1).trim()] as const]
+    })
+  const values = new Map(entries)
+  const num = (key: string) => parseInt(values.get(key) ?? "0") || 0
+  return {
+    loose: num("count"),
+    size_kib: num("size"),
+    in_pack: num("in-pack"),
+    packs: num("packs"),
+    size_pack_kib: num("size-pack"),
+    prune_packable: num("prune-packable"),
+    garbage: num("garbage"),
+    size_garbage_kib: num("size-garbage"),
+  }
+}
+
+async function tmpPacks(git: string) {
+  const dir = path.join(git, "objects", "pack")
+  const files = await fs.readdir(dir).catch(() => [])
+  const now = Date.now()
+  return (
+    await Promise.all(
+      files
+        .filter((name) => name.startsWith("tmp_pack_"))
+        .map(async (name) => {
+          const stat = await fs
+            .stat(path.join(dir, name))
+            .then((stat) => stat)
+            .catch(() => undefined)
+          if (!stat) return
+          return {
+            name,
+            age_ms: Math.max(0, Math.floor(now - stat.mtimeMs)),
+          }
+        }),
+    )
+  ).filter((item): item is { name: string; age_ms: number } => Boolean(item))
+}

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -119,14 +119,15 @@ export namespace Snapshot {
     const loose = parseInt(count.match(/count: (\d+)/)?.[1] ?? "0")
     if (loose < 100) return
 
-    await $`git --git-dir ${git} gc --auto`.quiet().nothrow()
+    await $`git --git-dir ${git} repack -d -l`.quiet().nothrow()
 
     // If still too many loose objects or packs, prune
     const after = await $`git --git-dir ${git} count-objects -v`.quiet().text()
+    const looseAfter = parseInt(after.match(/count: (\d+)/)?.[1] ?? "0")
     const packsCount = parseInt(after.match(/packs: (\d+)/)?.[1] ?? "0")
-    if (packsCount > 50) {
+    if (looseAfter > 100 || packsCount > 50) {
       await $`git --git-dir ${git} gc --prune=${prune}`.quiet().nothrow()
-      log.info("cleanup", { prune })
+      log.info("cleanup", { prune, loose: looseAfter, packs: packsCount })
     }
   }
 

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -416,7 +416,6 @@ export namespace Snapshot {
     const text = input.toLowerCase()
     if (text.includes("index.lock")) return true
     if (text.includes("another git process seems to be running")) return true
-    if (text.includes("unable to create") && text.includes("index.lock")) return true
     return false
   }
 

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -779,6 +779,34 @@ test("cleanup skips gc when loose object count is low", async () => {
   })
 })
 
+test("cleanup compacts loose objects when snapshot churn is high", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const file = `${tmp.path}/churn.txt`
+      for (const i of Array.from({ length: 80 }, (_, i) => i)) {
+        await Filesystem.write(file, `churn-${i}-${Date.now()}`)
+        expect(await Snapshot.track()).toBeTruthy()
+      }
+
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      const before = await $`git --git-dir ${git} count-objects -v`.quiet().text()
+      const beforeLoose = parseInt(before.match(/count: (\d+)/)?.[1] ?? "0")
+      expect(beforeLoose).toBeGreaterThanOrEqual(100)
+
+      await Snapshot.cleanup()
+
+      const after = await $`git --git-dir ${git} count-objects -v`.quiet().text()
+      const afterLoose = parseInt(after.match(/count: (\d+)/)?.[1] ?? "0")
+      const afterPacks = parseInt(after.match(/packs: (\d+)/)?.[1] ?? "0")
+      expect(afterLoose).toBeLessThan(beforeLoose)
+      expect(afterLoose).toBeLessThan(100)
+      expect(afterPacks).toBeGreaterThan(0)
+    },
+  })
+})
+
 test("high-contention snapshot churn leaves no git index lock", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

Closes #74

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `debug snapshot verify` churn harness for Phase 5 runtime validation and uses its findings to harden cleanup behavior. Cleanup now compacts high loose-object growth with `git repack -d -l` and keeps prune fallback when counts remain elevated.

### How did you verify your code works?

- Ran `bun run typecheck` from `packages/opencode`.
- Ran `bun test test/snapshot/snapshot.test.ts` from `packages/opencode`.
- Ran `OPENCODE_CONFIG_CONTENT='{"$schema":"https://opencode.ai/config.json","snapshot":true}' bun run packages/opencode/src/index.ts debug snapshot verify --iterations 12 --concurrency 6 --cleanup-every 3`.

### Screenshots / recordings

N/A (non-UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR