### PR TITLE
chore: disable opencode workflows

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,10 +1,7 @@
 name: opencode
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   opencode:


### PR DESCRIPTION
Disables opencode GitHub workflows by setting workflow_dispatch only.